### PR TITLE
Send Metrics in Batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,15 @@ require 'sidekiq/datadog/monitor/data'
 
 # Initiate a Sidekiq::Datadog::Monitor client instance.
 Sidekiq::Datadog::Monitor::Data.initialize!(
-    {agent_host: 'localhost', 
-     agent_port: 8125,
-     queue: 'queue name',
-     tags: ['env:production', 'product:product_name'], # optional
-     cron: "*/30 * * * *" # default: "*/1 * * * *"
-     } 
-    )
-
+  agent_host: 'localhost',
+  agent_port: 8125,
+  queue: 'queue name',
+  tags: ['env:production', 'product:product_name'], # optional
+  cron: "*/30 * * * *" # default: "*/1 * * * *",
+  batch: false # optional, default: false
+)
 ```
-`agent_host` and `agent_port` instantiate DogStatsD client 
+`agent_host` and `agent_port` instantiate DogStatsD client
 
 `queue` setting for background job that will gather and send Sidekiq metrics
 
@@ -46,6 +45,7 @@ Sidekiq::Datadog::Monitor::Data.initialize!(
 
 `cron` - schedule settings for background job that will gather and send Sidekiq metrics
 
+`batch` turns on sending DD metrics in batches. Make sure you don't have too many queues before enabling this option. The message with all tags must fit into [8KB of default DataDog buffer](https://docs.datadoghq.com/developers/dogstatsd/high_throughput/#enable-buffering-on-your-client) size.
 
 
 ## Development

--- a/lib/sidekiq/datadog/monitor/data.rb
+++ b/lib/sidekiq/datadog/monitor/data.rb
@@ -3,12 +3,13 @@ module Sidekiq
     module Monitor
       class Data
         class << self
-          attr_reader :agent_port, :agent_host, :tags, :env, :queue, :cron
+          attr_reader :agent_port, :agent_host, :tags, :env, :queue, :cron, :batch
 
           def initialize!(options)
             @agent_port, @agent_host, @queue = options.fetch_values(:agent_port, :agent_host, :queue)
             @tags = options[:tags] || []
             @cron = options[:cron] || '*/1 * * * *'
+            @batch = options[:batch] || false
 
             Sidekiq.configure_server do |config|
               SidekiqScheduler::Scheduler.dynamic = true

--- a/spec/sidekiq/datadog/monitor/data_spec.rb
+++ b/spec/sidekiq/datadog/monitor/data_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Sidekiq::Datadog::Monitor::Data do
       agent_port: 8125,
       tags: ['tag:tag', 'env:production'],
       queue: 'queue name',
-      cron: '*/30 * * * *'
+      cron: '*/30 * * * *',
+      batch: true
     }
   end
 
@@ -36,6 +37,7 @@ RSpec.describe Sidekiq::Datadog::Monitor::Data do
     it { expect(described_class.agent_host).to eql(options[:agent_host]) }
     it { expect(described_class.agent_port).to eql(options[:agent_port]) }
     it { expect(described_class.tags).to eql(options[:tags]) }
+    it { expect(described_class.batch).to be true }
   end
 
   context 'when options are not provided' do
@@ -58,6 +60,10 @@ RSpec.describe Sidekiq::Datadog::Monitor::Data do
 
       it 'tags is empty string' do
         expect(described_class.tags).to eql([])
+      end
+
+      it 'batch is false' do
+        expect(described_class.batch).to be false
       end
     end
   end


### PR DESCRIPTION
DataDog can send metrics in batches:
    https://docs.datadoghq.com/developers/dogstatsd/high_throughput/
It might be useful for some systems to reduce Network IOPs

We add a new option `batch: true|false` to the configuration in this
commit. We also fix a minor bug of initializing a new connection each
time worker sends data.