### PR TITLE
Update for using with dogstatsd-ruby ver. 5+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     sidekiq-datadog-monitor (0.2.1)
-      dogstatsd-ruby (>= 4.8.1, < 5)
+      dogstatsd-ruby (~> 5.0)
       sidekiq (>= 2.2.1)
       sidekiq-scheduler (~> 3.0)
 
@@ -14,7 +14,7 @@ GEM
     concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
     diff-lcs (1.4.4)
-    dogstatsd-ruby (4.8.3)
+    dogstatsd-ruby (5.5.0)
     e2mmap (0.1.0)
     et-orbi (1.2.7)
       tzinfo
@@ -66,11 +66,11 @@ GEM
     ruby-progressbar (1.10.1)
     rufus-scheduler (3.8.1)
       fugit (~> 1.1, >= 1.1.6)
-    sidekiq (6.4.2)
+    sidekiq (6.5.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sidekiq-scheduler (3.2.1)
+    sidekiq-scheduler (3.2.2)
       e2mmap
       redis (>= 3, < 5)
       rufus-scheduler (~> 3.2)

--- a/lib/sidekiq/datadog/monitor/data.rb
+++ b/lib/sidekiq/datadog/monitor/data.rb
@@ -3,13 +3,12 @@ module Sidekiq
     module Monitor
       class Data
         class << self
-          attr_reader :agent_port, :agent_host, :tags, :env, :queue, :cron, :batch
+          attr_reader :agent_port, :agent_host, :tags, :env, :queue, :cron
 
           def initialize!(options)
             @agent_port, @agent_host, @queue = options.fetch_values(:agent_port, :agent_host, :queue)
             @tags = options[:tags] || []
             @cron = options[:cron] || '*/1 * * * *'
-            @batch = options[:batch] || false
 
             Sidekiq.configure_server do |config|
               SidekiqScheduler::Scheduler.dynamic = true

--- a/lib/sidekiq/datadog/monitor/metrics_worker.rb
+++ b/lib/sidekiq/datadog/monitor/metrics_worker.rb
@@ -11,10 +11,8 @@ module Sidekiq
 
         def perform
           statsd = ::Datadog::Statsd.new(Data.agent_host, Data.agent_port)
-
-          return send_metrics(statsd) unless Data.batch
-
-          statsd.batch { |batch_statsd| send_metrics(batch_statsd) }
+          send_metrics(statsd)
+          statsd.close
         end
 
         private

--- a/sidekiq-datadog-monitor.gemspec
+++ b/sidekiq-datadog-monitor.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sidekiq', '>= 2.2.1'
   spec.add_dependency 'sidekiq-scheduler', '~> 3.0'
-  spec.add_dependency "dogstatsd-ruby", '>= 4.8.1', '< 5'
+  spec.add_dependency 'dogstatsd-ruby', '~> 5.0'
 end

--- a/spec/sidekiq/datadog/monitor/data_spec.rb
+++ b/spec/sidekiq/datadog/monitor/data_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe Sidekiq::Datadog::Monitor::Data do
       agent_port: 8125,
       tags: ['tag:tag', 'env:production'],
       queue: 'queue name',
-      cron: '*/30 * * * *',
-      batch: true
+      cron: '*/30 * * * *'
     }
   end
 
@@ -37,7 +36,6 @@ RSpec.describe Sidekiq::Datadog::Monitor::Data do
     it { expect(described_class.agent_host).to eql(options[:agent_host]) }
     it { expect(described_class.agent_port).to eql(options[:agent_port]) }
     it { expect(described_class.tags).to eql(options[:tags]) }
-    it { expect(described_class.batch).to be true }
   end
 
   context 'when options are not provided' do
@@ -60,10 +58,6 @@ RSpec.describe Sidekiq::Datadog::Monitor::Data do
 
       it 'tags is empty string' do
         expect(described_class.tags).to eql([])
-      end
-
-      it 'batch is false' do
-        expect(described_class.batch).to be false
       end
     end
   end

--- a/spec/sidekiq/datadog/monitor/metrics_worker_spec.rb
+++ b/spec/sidekiq/datadog/monitor/metrics_worker_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Sidekiq::Datadog::Monitor::MetricsWorker do
   let(:perform) { described_class.new.perform }
-  let(:statsd) { instance_double(Datadog::Statsd, gauge: true) }
+  let(:statsd) { instance_double(Datadog::Statsd, gauge: true, close: true) }
   let(:stats) { instance_double(Sidekiq::Stats) }
   let(:stats_queue) { instance_double(Sidekiq::Queue) }
 
@@ -13,8 +13,7 @@ RSpec.describe Sidekiq::Datadog::Monitor::MetricsWorker do
       agent_port: 8125,
       tags: ['tag:tag', 'env:production'],
       queue: 'critical',
-      cron: '*/30 * * * *',
-      batch: batch
+      cron: '*/30 * * * *'
     }
   end
 
@@ -32,33 +31,11 @@ RSpec.describe Sidekiq::Datadog::Monitor::MetricsWorker do
     perform
   end
 
-  context 'when the batch mode is off' do
-    let(:batch) { false }
-
-    it 'posts queue size' do
-      expect(statsd).to have_received(:gauge).with('sidekiq.queue.size', 100, { tags: tags })
-    end
-
-    it 'posts queue latency' do
-      expect(statsd).to have_received(:gauge).with('sidekiq.queue.latency', 5000, { tags: tags })
-    end
+  it 'posts queue size' do
+    expect(statsd).to have_received(:gauge).with('sidekiq.queue.size', 100, { tags: tags })
   end
 
-  context 'when the batch mode is on' do
-    let(:batch) { true }
-
-    let(:statsd) do
-      instance_double(Datadog::Statsd, gauge: true).tap do |s|
-        allow(s).to receive(:batch).and_yield(s)
-      end
-    end
-
-    it 'posts queue size' do
-      expect(statsd).to have_received(:gauge).with('sidekiq.queue.size', 100, { tags: tags })
-    end
-
-    it 'posts queue latency' do
-      expect(statsd).to have_received(:gauge).with('sidekiq.queue.latency', 5000, { tags: tags })
-    end
+  it 'posts queue latency' do
+    expect(statsd).to have_received(:gauge).with('sidekiq.queue.latency', 5000, { tags: tags })
   end
 end


### PR DESCRIPTION
`dogstatsd-ruby` updated its threading model, so we have to update accordingly.

https://github.com/DataDog/dogstatsd-ruby#migrating-from-v4x-to-v5x