### PR TITLE
Add scheduled metric

### DIFF
--- a/lib/sidekiq/datadog/monitor/metrics_worker.rb
+++ b/lib/sidekiq/datadog/monitor/metrics_worker.rb
@@ -23,6 +23,7 @@ module Sidekiq
 
             post_queue_latency(statsd, queue_name)
           end
+          post_scheduled_size(statsd)
         end
 
         def post_queue_size(statsd, queue_name, size)
@@ -34,6 +35,12 @@ module Sidekiq
           latency = Sidekiq::Queue.new(queue_name).latency
           statsd.gauge('sidekiq.queue.latency', latency,
                        tags: ["queue_name:#{queue_name}"].concat(Data.tags))
+        end
+
+        def post_scheduled_size(statsd)
+          scheduled_size = Sidekiq::Stats.new.scheduled_size
+          statsd.gauge('sidekiq.scheduled', scheduled_size,
+                       tags: ['scheduled_size'].concat(Data.tags))
         end
       end
     end

--- a/lib/sidekiq/datadog/monitor/version.rb
+++ b/lib/sidekiq/datadog/monitor/version.rb
@@ -1,7 +1,7 @@
 module Sidekiq
   module Datadog
     module Monitor
-      VERSION = '0.2.1'.freeze
+      VERSION = '0.4.0'.freeze
     end
   end
 end

--- a/spec/sidekiq/datadog/monitor/metrics_worker_spec.rb
+++ b/spec/sidekiq/datadog/monitor/metrics_worker_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Sidekiq::Datadog::Monitor::MetricsWorker do
   let(:stats_queue) { instance_double(Sidekiq::Queue) }
 
   let(:queues) { { 'default' => 100 } }
+  let(:scheduled_size) { 500 }
   let(:tags) { ['queue_name:default', 'tag:tag', 'env:production'] }
+  let(:schedule_tags) { ['scheduled_size', 'tag:tag', 'env:production'] }
 
   let(:options) do
     {
@@ -26,6 +28,7 @@ RSpec.describe Sidekiq::Datadog::Monitor::MetricsWorker do
 
     allow(Datadog::Statsd).to receive(:new).and_return(statsd)
     allow(stats).to receive(:queues).and_return(queues)
+    allow(stats).to receive(:scheduled_size).and_return(scheduled_size)
     allow(statsd).to receive(:gauge)
 
     perform
@@ -37,5 +40,9 @@ RSpec.describe Sidekiq::Datadog::Monitor::MetricsWorker do
 
   it 'posts queue latency' do
     expect(statsd).to have_received(:gauge).with('sidekiq.queue.latency', 5000, { tags: tags })
+  end
+
+  it 'posts scheduled size' do
+    expect(statsd).to have_received(:gauge).with('sidekiq.scheduled', 500, { tags: schedule_tags })
   end
 end


### PR DESCRIPTION
This sends the `scheduled` metric to Datadog.

I've tested this on my end as well and the metric seems to be sent to Datadog