### PR TITLE
Swallow 'Start sender first' during beat/shutdown race

### DIFF
--- a/lib/sidekiq/datadog/monitor.rb
+++ b/lib/sidekiq/datadog/monitor.rb
@@ -35,8 +35,11 @@ module Sidekiq
         def send_metrics
           sender&.send_metrics
         rescue ArgumentError => e
-          # Ignore this error. Sometimes sender hasn't yet started when we send metrics for the first time on boot
-          return if sender && e.message == 'Start sender first'
+          # Ignore this error. The statsd sender may not be started yet (first beat on boot) or may have
+          # already been stopped (a beat racing with shutdown!, which closes statsd and nils @sender).
+          # We must not re-check @sender here: during the shutdown race it is already nil, which would
+          # let the harmless error escape into the Sidekiq error handler.
+          return if e.message == 'Start sender first'
 
           raise
         end

--- a/spec/sidekiq/datadog/monitor_spec.rb
+++ b/spec/sidekiq/datadog/monitor_spec.rb
@@ -96,6 +96,21 @@ RSpec.describe Sidekiq::Datadog::Monitor do
       end
     end
 
+    context 'when sender raises after shutdown niled it (beat/shutdown race)' do
+      before do
+        # The beat passes the `sender&.` guard, then shutdown! runs concurrently: it nils @sender and
+        # closes statsd, so the in-flight gauge call raises 'Start sender first'.
+        allow(described_class.sender).to receive(:send_metrics) do
+          described_class.instance_variable_set(:@sender, nil)
+          raise ArgumentError, 'Start sender first'
+        end
+      end
+
+      it 'handling exception' do
+        expect { described_class.send_metrics }.not_to raise_error
+      end
+    end
+
     context 'when sender throws error' do
       before do
         allow(described_class.sender).to receive(:send_metrics).and_raise('Some error')


### PR DESCRIPTION
send_metrics already rescued ArgumentError to ignore the harmless 'Start sender first' error from dogstatsd when the statsd sender isn't ready. But the guard re-checked @sender:

    return if sender && e.message == 'Start sender first'

That handles the boot race (sender still set) but not the shutdown race: when a :beat event is in flight and :shutdown runs concurrently, shutdown! nils @sender and closes statsd, so the in-flight gauge call raises 'Start sender first' while @sender is already nil. The guard then re-raises and the error escapes into the Sidekiq error handler (reported to Sentry as "Exception during Sidekiq lifecycle event").

Drop the redundant `sender &&` check — the error message alone tells us it's safe to ignore — so both the boot and shutdown races are handled. Add a regression test for the shutdown race.